### PR TITLE
Better UX on Step3 + request-handling

### DIFF
--- a/src/app/connected-components/engangsstonad-steg/Steg3.tsx
+++ b/src/app/connected-components/engangsstonad-steg/Steg3.tsx
@@ -397,7 +397,7 @@ export class Steg3 extends React.Component<Props> {
                         twoColumns={true}
                     />
                 </FormBlock>
-                <FormBlock visible={iNorgeNeste12Mnd === false}>
+                <FormBlock visible={iNorgeNeste12Mnd === false && (iNorgeSiste12Mnd === true || (iNorgeSiste12Mnd === false && tidligerePerioder.length > 0))}>
                     <CountryPicker
                         label={getMessage(intl, 'medlemmskap.text.jegSkalBo')}
                         language={language}

--- a/src/app/connected-components/soknad-sendt/SøknadSendt.tsx
+++ b/src/app/connected-components/soknad-sendt/SøknadSendt.tsx
@@ -25,7 +25,7 @@ interface StateProps {
 
 type Props = StateProps & InjectedIntlProps;
 
-export class EngangsstonadCompleted extends React.Component<Props> {
+export class SøknadSendt extends React.Component<Props> {
     receiptText() {
         const { kvittering } = this.props;
         return (
@@ -70,4 +70,4 @@ const mapStateToProps = (state: any) => ({
     kvittering: state.apiReducer.kvittering
 });
 
-export default connect<StateProps>(mapStateToProps)(injectIntl(EngangsstonadCompleted));
+export default connect<StateProps>(mapStateToProps)(injectIntl(SøknadSendt));

--- a/src/app/redux/reducers/soknadReducer.ts
+++ b/src/app/redux/reducers/soknadReducer.ts
@@ -88,7 +88,16 @@ const soknadReducer = (state = getDefaultState(), action: SoknadActionTypes) => 
             return { ...state, utenlandsopphold: { ...utenlandsopphold, fødselINorge } };
         case SoknadActionKeys.SET_I_NORGE_SISTE_12_MND:
             const { iNorgeSiste12Mnd } = action;
-            return { ...state, utenlandsopphold: { ...getDefaultState().utenlandsopphold, iNorgeSiste12Mnd } };
+            return {
+                ...state, utenlandsopphold: {
+                    ...getDefaultState().utenlandsopphold,
+                    iNorgeSiste12Mnd,
+                    iNorgeNeste12Mnd: state.utenlandsopphold.iNorgeNeste12Mnd,
+                    fødselINorge: state.utenlandsopphold.fødselINorge,
+                    tidligerePerioder: state.utenlandsopphold.tidligerePerioder,
+                    senerePerioder: state.utenlandsopphold.senerePerioder
+                }
+            };
         case SoknadActionKeys.SET_I_NORGE_NESTE_12_MND:
             const { iNorgeNeste12Mnd } = action;
             return {
@@ -96,8 +105,10 @@ const soknadReducer = (state = getDefaultState(), action: SoknadActionTypes) => 
                 utenlandsopphold: {
                     ...utenlandsopphold,
                     iNorgeNeste12Mnd,
-                    fødselINorge: undefined,
-                    senerePerioder: getDefaultState().utenlandsopphold.senerePerioder
+                    iNorgeSiste12Mnd: state.utenlandsopphold.iNorgeSiste12Mnd,
+                    fødselINorge: state.utenlandsopphold.fødselINorge,
+                    tidligerePerioder: state.utenlandsopphold.tidligerePerioder,
+                    senerePerioder: state.utenlandsopphold.senerePerioder
                 }
             };
         case SoknadActionKeys.SET_ER_BARNET_FODT:

--- a/src/app/redux/sagas/sagas.ts
+++ b/src/app/redux/sagas/sagas.ts
@@ -2,6 +2,7 @@ import { all, put, call, takeEvery } from 'redux-saga/effects';
 import Api from '../../api/api';
 import { ApiActionKeys, GetPersonActionType } from '../actions/api/apiActionDefinitions';
 import { EngangsstonadSoknadResponse } from '../../types/services/EngangsstonadSoknadResponse';
+import apiUtils from './../../util/apiUtils';
 
 // tslint:disable-next-line:no-any
 function* getPerson(action: any) {
@@ -17,7 +18,7 @@ function* getPerson(action: any) {
 // tslint:disable-next-line:no-any
 function* sendSoknad(action: any) {
     try {
-        const response = yield call(Api.sendSoknad, action.soknad, action.vedlegg);
+        const response = yield call(Api.sendSoknad, apiUtils.cleanupSøknad(action.soknad), action.vedlegg);
         const kvittering: EngangsstonadSoknadResponse = response.data;
         yield put({ type: ApiActionKeys.SEND_SOKNAD_SUCCESS, kvittering });
     } catch (error) {

--- a/src/app/util/apiUtils.ts
+++ b/src/app/util/apiUtils.ts
@@ -1,0 +1,18 @@
+import EngangsstonadSoknad from '../types/domain/EngangsstonadSoknad';
+
+export default {
+    cleanupSøknad: (søknad: EngangsstonadSoknad) => {
+        const { utenlandsopphold } = søknad;
+        const { iNorgeSiste12Mnd, tidligerePerioder } = utenlandsopphold;
+        const { iNorgeNeste12Mnd, senerePerioder } = utenlandsopphold;
+
+        if (iNorgeSiste12Mnd && tidligerePerioder.length > 0) {
+            søknad.utenlandsopphold.tidligerePerioder = [];
+        }
+        if (iNorgeNeste12Mnd && senerePerioder.length > 0) {
+            søknad.utenlandsopphold.senerePerioder = [];
+        }
+
+        return søknad;
+    }
+};

--- a/src/app/util/stepUtil.ts
+++ b/src/app/util/stepUtil.ts
@@ -33,21 +33,25 @@ export const shouldDisplayNextButtonOnStep2 = (
     }
 };
 
+export const iNorgeSiste12MndIsValid = (u: Utenlandsopphold) => {
+    return u.iNorgeSiste12Mnd === true || (u.iNorgeSiste12Mnd === false && u.tidligerePerioder.length > 0); 
+};
+
+export const iNorgeNeste12MndIsValid = (u: Utenlandsopphold) => {
+    return u.iNorgeNeste12Mnd === true || (u.iNorgeNeste12Mnd === false && u.senerePerioder.length > 0);
+};
+
 export const shouldDisplayNextButtonOnStep3 = (
     barn: Barn,
     utenlandsopphold: Utenlandsopphold
 ) => {
     if (utenlandsopphold.iNorgeNeste12Mnd === false) {
-        return (
-            utenlandsopphold.senerePerioder.length > 0 &&
-            (datoIsSet(barn.fødselsdatoer) ||
-                utenlandsopphold.fødselINorge !== undefined)
-        );
+        return ((datoIsSet(barn.fødselsdatoer) || utenlandsopphold.fødselINorge !== undefined)) &&
+            iNorgeNeste12MndIsValid(utenlandsopphold) && iNorgeSiste12MndIsValid(utenlandsopphold);
     } else {
         return (
-            utenlandsopphold.fødselINorge !== undefined ||
-            (datoIsSet(barn.fødselsdatoer) &&
-                utenlandsopphold.iNorgeNeste12Mnd !== undefined)
+            utenlandsopphold.fødselINorge !== undefined || (datoIsSet(barn.fødselsdatoer) && utenlandsopphold.iNorgeNeste12Mnd !== undefined) &&
+            iNorgeNeste12MndIsValid(utenlandsopphold) && iNorgeSiste12MndIsValid(utenlandsopphold)
         );
     }
 };


### PR DESCRIPTION
This fix makes sure utenlandsopphold added to lists for tidligerePerioder and senerePerioder
are not reset when changing values of form-elements elsewhere in the form, including the RadioPanels
related to the lists themselves.

This commit also makes sure that we do not send tidligerePerioder- and senerePerioder-data from the
state of the application to foreldrepengesoknad-api when the user has added an Utenlandsopphold to any of the lists, followed by
stating they have been in norway / will live in norway the previous and/or next 12 months.