### PR TITLE
Type name changes

### DIFF
--- a/src/app/components/country-picker/CountryList.tsx
+++ b/src/app/components/country-picker/CountryList.tsx
@@ -1,24 +1,24 @@
 import * as React from 'react';
 import CountryListElement from './CountryListElement';
-import { Periode } from '../../types/domain/Utenlandsopphold';
+import { Utenlandsopphold } from '../../types/domain/InformasjonOmUtenlandsopphold';
 
 import './countryPicker.less';
 
 interface CountryListProps {
-    utenlandsoppholdListe: Periode[];
+    utenlandsoppholdListe: Utenlandsopphold[];
 }
 
 export const CountrySummaryList: React.StatelessComponent<CountryListProps> = props => (
     <ul className="countryList countryList--summary">
-        {props.utenlandsoppholdListe.map((periode: Periode, index: number) => (
+        {props.utenlandsoppholdListe.map((periode: Utenlandsopphold, index: number) => (
             <CountryListElement key={index} utenlandsopphold={periode} />
         ))}
     </ul>
 );
 
 interface EditableCountryListProps extends CountryListProps {
-    onEditClick: (periode: Periode) => void;
-    onDeleteClick: (periode: Periode) => void;
+    onEditClick: (periode: Utenlandsopphold) => void;
+    onDeleteClick: (periode: Utenlandsopphold) => void;
 }
 
 export const CountryList: React.StatelessComponent<EditableCountryListProps> = props =>

--- a/src/app/components/country-picker/CountryListElement.tsx
+++ b/src/app/components/country-picker/CountryListElement.tsx
@@ -4,16 +4,16 @@ import classnames from 'classnames';
 import { injectIntl, InjectedIntlProps } from 'react-intl';
 import { ISODateToMaskedInput } from 'util/date/dateUtils';
 import getMessage from 'util/i18n/i18nUtils';
-import { Periode } from '../../types/domain/Utenlandsopphold';
+import { Utenlandsopphold } from '../../types/domain/InformasjonOmUtenlandsopphold';
 
 import './countryPicker.less';
 import SlettKnapp from 'common/components/slett-knapp/SlettKnapp';
 import LinkButton from 'components/link-button/LinkButton';
 
 interface OwnProps {
-    utenlandsopphold: Periode;
-    onDeleteClick?: (periode: Periode) => void;
-    onEditClick?: (periode: Periode) => void;
+    utenlandsopphold: Utenlandsopphold;
+    onDeleteClick?: (periode: Utenlandsopphold) => void;
+    onEditClick?: (periode: Utenlandsopphold) => void;
 }
 
 type Props = OwnProps & InjectedIntlProps;

--- a/src/app/components/country-picker/CountryModal.tsx
+++ b/src/app/components/country-picker/CountryModal.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { injectIntl, InjectedIntlProps, FormattedMessage } from 'react-intl';
 import { Undertittel } from 'nav-frontend-typografi';
 import { Knapp, Hovedknapp } from 'nav-frontend-knapper';
-import { Periode } from '../../types/domain/Utenlandsopphold';
+import { Utenlandsopphold } from '../../types/domain/InformasjonOmUtenlandsopphold';
 import CountrySelect from 'components/country-select/CountrySelect';
 import DateInput from 'components/date-input/DateInput';
 import { Tidsperiode, Avgrensninger } from 'nav-datovelger';
@@ -14,11 +14,11 @@ const Modal = require('nav-frontend-modal').default;
 
 interface OwnProps {
     language: string;
-    utenlandsopphold?: Periode;
-    alleUtenlandsopphold?: Periode[];
+    utenlandsopphold?: Utenlandsopphold;
+    alleUtenlandsopphold?: Utenlandsopphold[];
     label: string;
     tidsperiode?: Tidsperiode;
-    onSubmit: (periode: Periode) => void;
+    onSubmit: (periode: Utenlandsopphold) => void;
     closeModal: () => void;
     validateLand?: (data: any) => Feil | undefined;
     validateFom?: (data: any) => Feil | undefined;
@@ -44,7 +44,7 @@ interface State {
     formData: PeriodeForm;
 }
 
-const getValidPeriode = (formData: PeriodeForm): Periode | undefined => {
+const getValidPeriode = (formData: PeriodeForm): Utenlandsopphold | undefined => {
     const { land, fom, tom } = formData;
     if (land && fom && tom) {
         return {
@@ -65,7 +65,7 @@ const getDateFromString = (dato?: string) => {
     return undefined;
 };
 
-const getRegistrertePerioder = (alleOpphold: Periode[], gjeldendeOpphold?: Periode): Tidsperiode[] => {
+const getRegistrertePerioder = (alleOpphold: Utenlandsopphold[], gjeldendeOpphold?: Utenlandsopphold): Tidsperiode[] => {
     let arr = gjeldendeOpphold ? alleOpphold.filter(o => o !== gjeldendeOpphold) : alleOpphold;
     return arr.map(opphold => ({
         startdato: new Date(opphold.varighet.fom),
@@ -73,7 +73,7 @@ const getRegistrertePerioder = (alleOpphold: Periode[], gjeldendeOpphold?: Perio
     }));
 };
 
-const getDefaultState = (utenlandsopphold?: Periode): State => {
+const getDefaultState = (utenlandsopphold?: Utenlandsopphold): State => {
     if (utenlandsopphold) {
         return {
             erEndring: true,

--- a/src/app/components/country-picker/CountryPicker.tsx
+++ b/src/app/components/country-picker/CountryPicker.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 const { Knapp } = require('nav-frontend-knapper');
 import CountryModal from 'components/country-picker/CountryModal';
 import { CountryList } from 'components/country-picker/CountryList';
-import { Periode } from '../../types/domain/Utenlandsopphold';
+import { Utenlandsopphold } from '../../types/domain/InformasjonOmUtenlandsopphold';
 import './countryPicker.less';
 import LabelText from 'common/components/labeltekst/Labeltekst';
 import { Tidsperiode } from 'nav-datovelger';
@@ -17,17 +17,17 @@ interface Validators {
 interface Props {
     label: string;
     language: string;
-    utenlandsoppholdListe: Periode[];
+    utenlandsoppholdListe: Utenlandsopphold[];
     tidsperiode?: Tidsperiode;
-    addVisit: (periode: Periode) => void;
-    deleteVisit: (periode: Periode) => void;
-    editVisit: (periode: Periode, index: number) => void;
+    addVisit: (periode: Utenlandsopphold) => void;
+    deleteVisit: (periode: Utenlandsopphold) => void;
+    editVisit: (periode: Utenlandsopphold, index: number) => void;
     validators?: Validators;
 }
 
 interface State {
     isOpen: boolean;
-    editVisit?: Periode;
+    editVisit?: Utenlandsopphold;
 }
 
 class CountryPicker extends React.Component<Props, State> {
@@ -53,20 +53,20 @@ class CountryPicker extends React.Component<Props, State> {
         this.setState({ isOpen: false, editVisit: undefined });
     }
 
-    addVisit(periode: Periode) {
+    addVisit(periode: Utenlandsopphold) {
         this.props.addVisit(periode);
         this.setState({ isOpen: false });
     }
 
-    onEditClick(periode: Periode) {
+    onEditClick(periode: Utenlandsopphold) {
         this.setState({ editVisit: periode, isOpen: true });
     }
 
-    onDeleteClick(periode: Periode) {
+    onDeleteClick(periode: Utenlandsopphold) {
         this.props.deleteVisit(periode);
     }
 
-    onModalSubmit(periode: Periode) {
+    onModalSubmit(periode: Utenlandsopphold) {
         const { editVisit } = this.state;
         if (editVisit === undefined) {
             this.props.addVisit(periode);
@@ -86,15 +86,15 @@ class CountryPicker extends React.Component<Props, State> {
                     <div className="blokk-s">
                         <CountryList
                             utenlandsoppholdListe={this.props.utenlandsoppholdListe}
-                            onEditClick={(periode: Periode) => this.onEditClick(periode)}
-                            onDeleteClick={(periode: Periode) => this.onDeleteClick(periode)}
+                            onEditClick={(periode: Utenlandsopphold) => this.onEditClick(periode)}
+                            onDeleteClick={(periode: Utenlandsopphold) => this.onDeleteClick(periode)}
                         />
                     </div>
                 )}
                 {this.state.isOpen && (
                     <CountryModal
                         utenlandsopphold={this.state.editVisit}
-                        onSubmit={(periode: Periode) => this.onModalSubmit(periode)}
+                        onSubmit={(periode: Utenlandsopphold) => this.onModalSubmit(periode)}
                         closeModal={() => this.closeModal()}
                         language={this.props.language}
                         label={this.props.label}

--- a/src/app/connected-components/engangsstonad-steg/Steg3.tsx
+++ b/src/app/connected-components/engangsstonad-steg/Steg3.tsx
@@ -3,7 +3,7 @@ import { injectIntl, InjectedIntlProps } from 'react-intl';
 import * as moment from 'moment';
 import getMessage from 'util/i18n/i18nUtils';
 import { soknadActionCreators as soknad } from '../../redux/actions';
-import Utenlandsopphold, { Periode } from '../../types/domain/Utenlandsopphold';
+import InformasjonOmUtenlandsopphold, { Utenlandsopphold } from '../../types/domain/InformasjonOmUtenlandsopphold';
 import { DispatchProps } from 'common/redux/types';
 import CountryPicker from '../../components/country-picker/CountryPicker';
 import Barn from '../../types/domain/Barn';
@@ -16,7 +16,7 @@ import { connect } from 'react-redux';
 
 interface StateProps {
     barn: Barn;
-    utenlandsopphold: Utenlandsopphold;
+    informasjonOmUtenlandsopphold: InformasjonOmUtenlandsopphold;
     vedlegg: File[];
     language: string;
 }
@@ -44,8 +44,8 @@ class Steg3 extends React.Component<Props> {
     }
 
     overlapsWithOtherUtenlandsopphold(momentFom: any, momentTom: any, utenlandsoppholdInEditMode: any) {
-        const { tidligerePerioder, senerePerioder } = this.props.utenlandsopphold;
-        const perioder = [...tidligerePerioder, ...senerePerioder];
+        const { tidligereOpphold, senereOpphold } = this.props.informasjonOmUtenlandsopphold;
+        const perioder = [...tidligereOpphold, ...senereOpphold];
         const overlappendePeriode = perioder.find(periode => {
             if (periode !== utenlandsoppholdInEditMode) {
                 const { varighet } = periode;
@@ -175,7 +175,7 @@ class Steg3 extends React.Component<Props> {
     }
 
     getINorgeSiste12SelectedValue() {
-        const { iNorgeSiste12Mnd } = this.props.utenlandsopphold;
+        const { iNorgeSiste12Mnd } = this.props.informasjonOmUtenlandsopphold;
         if (iNorgeSiste12Mnd === true) {
             return 'norway';
         } else if (iNorgeSiste12Mnd === false) {
@@ -186,7 +186,7 @@ class Steg3 extends React.Component<Props> {
     }
 
     getINorgeNeste12SelectedValue() {
-        const { iNorgeNeste12Mnd } = this.props.utenlandsopphold;
+        const { iNorgeNeste12Mnd } = this.props.informasjonOmUtenlandsopphold;
         if (iNorgeNeste12Mnd === true) {
             return 'norway';
         } else if (iNorgeNeste12Mnd === false) {
@@ -197,7 +197,7 @@ class Steg3 extends React.Component<Props> {
     }
 
     getFødselINorgeSelectedValue() {
-        const { fødselINorge } = this.props.utenlandsopphold;
+        const { fødselINorge } = this.props.informasjonOmUtenlandsopphold;
         if (fødselINorge === true) {
             return 'norway';
         } else if (fødselINorge === false) {
@@ -208,8 +208,8 @@ class Steg3 extends React.Component<Props> {
     }
 
     render() {
-        const { dispatch, intl, utenlandsopphold, barn, language } = this.props;
-        const { iNorgeSiste12Mnd, iNorgeNeste12Mnd, tidligerePerioder, senerePerioder } = utenlandsopphold;
+        const { dispatch, intl, informasjonOmUtenlandsopphold, barn, language } = this.props;
+        const { iNorgeSiste12Mnd, iNorgeNeste12Mnd, tidligereOpphold, senereOpphold } = informasjonOmUtenlandsopphold;
 
         const tidsperiodeForegående: Tidsperiode = {
             startdato: moment()
@@ -259,10 +259,10 @@ class Steg3 extends React.Component<Props> {
                     <CountryPicker
                         label={getMessage(intl, 'medlemmskap.text.jegBodde')}
                         language={language}
-                        utenlandsoppholdListe={tidligerePerioder}
-                        addVisit={(periode: Periode) => dispatch(soknad.addTidligereUtenlandsoppholdPeriode(periode))}
-                        editVisit={(periode: Periode, i: number) => dispatch(soknad.editTidligereUtenlandsoppholdPeriode(periode, i))}
-                        deleteVisit={(periode: Periode) => dispatch(soknad.deleteTidligereUtenlandsoppholdPeriode(periode))}
+                        utenlandsoppholdListe={tidligereOpphold}
+                        addVisit={(periode: Utenlandsopphold) => dispatch(soknad.addTidligereUtenlandsoppholdPeriode(periode))}
+                        editVisit={(periode: Utenlandsopphold, i: number) => dispatch(soknad.editTidligereUtenlandsoppholdPeriode(periode, i))}
+                        deleteVisit={(periode: Utenlandsopphold) => dispatch(soknad.deleteTidligereUtenlandsoppholdPeriode(periode))}
                         tidsperiode={tidsperiodeForegående}
                         validators={{
                             validateLand: this.validateLand,
@@ -271,7 +271,7 @@ class Steg3 extends React.Component<Props> {
                         }}
                     />
                 </FormBlock>
-                <FormBlock visible={iNorgeSiste12Mnd || tidligerePerioder.length > 0}>
+                <FormBlock visible={iNorgeSiste12Mnd || tidligereOpphold.length > 0}>
                     <RadioPanelGruppeResponsive
                         legend={getMessage(intl, 'medlemmskap.text.neste12mnd')}
                         name="iNorgeNeste12"
@@ -294,16 +294,16 @@ class Steg3 extends React.Component<Props> {
                 </FormBlock>
                 <FormBlock
                     visible={
-                        iNorgeNeste12Mnd === false && (iNorgeSiste12Mnd === true || (iNorgeSiste12Mnd === false && tidligerePerioder.length > 0))
+                        iNorgeNeste12Mnd === false && (iNorgeSiste12Mnd === true || (iNorgeSiste12Mnd === false && tidligereOpphold.length > 0))
                     }
                 >
                     <CountryPicker
                         label={getMessage(intl, 'medlemmskap.text.jegSkalBo')}
                         language={language}
-                        utenlandsoppholdListe={senerePerioder}
-                        addVisit={(periode: Periode) => dispatch(soknad.addSenereUtenlandsoppholdPeriode(periode))}
-                        editVisit={(periode: Periode, i: number) => dispatch(soknad.editSenereUtenlandsoppholdPeriode(periode, i))}
-                        deleteVisit={(periode: Periode) => dispatch(soknad.deleteSenereUtenlandsoppholdPeriode(periode))}
+                        utenlandsoppholdListe={senereOpphold}
+                        addVisit={(periode: Utenlandsopphold) => dispatch(soknad.addSenereUtenlandsoppholdPeriode(periode))}
+                        editVisit={(periode: Utenlandsopphold, i: number) => dispatch(soknad.editSenereUtenlandsoppholdPeriode(periode, i))}
+                        deleteVisit={(periode: Utenlandsopphold) => dispatch(soknad.deleteSenereUtenlandsoppholdPeriode(periode))}
                         tidsperiode={tidsperiodeKommende}
                         validators={{
                             validateLand: this.validateLand,
@@ -314,8 +314,8 @@ class Steg3 extends React.Component<Props> {
                 </FormBlock>
                 <FormBlock
                     visible={
-                        (iNorgeSiste12Mnd || tidligerePerioder.length > 0) && (
-                            (iNorgeNeste12Mnd || senerePerioder.length > 0))
+                        (iNorgeSiste12Mnd || tidligereOpphold.length > 0) && (
+                            (iNorgeNeste12Mnd || senereOpphold.length > 0))
                     }
                 >
                     <RadioPanelGruppeResponsive
@@ -359,7 +359,7 @@ class Steg3 extends React.Component<Props> {
 }
 
 const mapStateToProps = (state: any) => ({
-    utenlandsopphold: state.soknadReducer.utenlandsopphold,
+    informasjonOmUtenlandsopphold: state.soknadReducer.informasjonOmUtenlandsopphold,
     barn: state.soknadReducer.barn,
     vedlegg: state.soknadReducer.vedlegg,
     language: state.commonReducer.language

--- a/src/app/connected-components/engangsstonad-steg/Steg4.tsx
+++ b/src/app/connected-components/engangsstonad-steg/Steg4.tsx
@@ -14,7 +14,7 @@ import Person from 'app/types/domain/Person';
 import { FodtBarn, UfodtBarn } from 'app/types/domain/Barn';
 import AnnenForelder from 'app/types/domain/AnnenForelder';
 import { DispatchProps } from 'common/redux/types';
-import Utenlandsopphold from 'app/types/domain/Utenlandsopphold';
+import InformasjonOmUtenlandsopphold from 'app/types/domain/InformasjonOmUtenlandsopphold';
 
 import { EngangsstonadSoknadResponse } from '../../types/services/EngangsstonadSoknadResponse';
 import OppsummeringBarn from './../oppsummering/BarnOppsummering';
@@ -30,7 +30,7 @@ import { Attachment } from 'storage/attachment/types/Attachment';
 interface StateProps {
     bekreftetInformasjon: boolean;
     person: Person;
-    utenlandsopphold: Utenlandsopphold;
+    informasjonOmUtenlandsopphold: InformasjonOmUtenlandsopphold;
     barn: FodtBarn & UfodtBarn;
     vedlegg: Attachment[];
     annenForelder: AnnenForelder;
@@ -63,7 +63,7 @@ class Steg4 extends React.Component<Props> {
                 </div>
                 <OppsummeringBarn barn={barn} vedlegg={this.props.vedlegg} />
                 {Object.keys(this.props.annenForelder).length > 0 && <OppsummeringDenAndreForeldren annenForelder={this.props.annenForelder} />}
-                <OppsummeringUtenlandsopphold utenlandsopphold={this.props.utenlandsopphold} erBarnetFødt={barn.erBarnetFødt} />
+                <OppsummeringUtenlandsopphold informasjonOmUtenlandsopphold={this.props.informasjonOmUtenlandsopphold} erBarnetFødt={barn.erBarnetFødt} />
                 <div className="blokk-m">
                     <div className="es-skjema__feilomrade--ingenBakgrunnsfarge">
                         <ValidGroup
@@ -94,7 +94,7 @@ const mapStateToProps = (state: any) => ({
     barn: state.soknadReducer.barn,
     vedlegg: state.attachmentReducer,
     annenForelder: state.soknadReducer.annenForelder,
-    utenlandsopphold: state.soknadReducer.utenlandsopphold,
+    informasjonOmUtenlandsopphold: state.soknadReducer.informasjonOmUtenlandsopphold,
     soknadPostResponse: state.apiReducer.soknad
 });
 export default connect<StateProps>(mapStateToProps)(injectIntl(Steg4));

--- a/src/app/connected-components/engangsstonad-steg/steg.config.ts
+++ b/src/app/connected-components/engangsstonad-steg/steg.config.ts
@@ -11,7 +11,7 @@ import {
 } from 'util/stepUtil';
 import Person from 'app/types/domain/Person';
 import Barn from '../../types/domain/Barn';
-import Utenlandsopphold from '../../types/domain/Utenlandsopphold';
+import InformasjonOmUtenlandsopphold from '../../types/domain/InformasjonOmUtenlandsopphold';
 import AnnenForelder from '../../types/domain/AnnenForelder';
 import { StepConfig } from 'app/types/StepConfig';
 import { Attachment } from 'storage/attachment/types/Attachment';
@@ -20,7 +20,7 @@ export interface NextStepCondition {
     type: string;
     barn: Barn;
     annenForelder: AnnenForelder;
-    utenlandsopphold: Utenlandsopphold;
+    informasjonOmUtenlandsopphold: InformasjonOmUtenlandsopphold;
     vedlegg: Attachment[];
 }
 
@@ -44,7 +44,7 @@ const stepConfig = [
         stegIndikatorLabelIntlId: 'medlemmskap.sectionheading',
         component: Steg3,
         nextStepCondition: (data: NextStepCondition) =>
-            shouldDisplayNextButtonOnStep3(data.barn, data.utenlandsopphold)
+            shouldDisplayNextButtonOnStep3(data.barn, data.informasjonOmUtenlandsopphold)
     },
     {
         fortsettKnappLabelIntlId: 'standard.sectionheading',

--- a/src/app/connected-components/oppsummering/UtenlandsoppholdOppsummering.tsx
+++ b/src/app/connected-components/oppsummering/UtenlandsoppholdOppsummering.tsx
@@ -3,7 +3,7 @@ import { EtikettLiten } from 'nav-frontend-typografi';
 
 import DisplayTextWithLabel from 'components/display-text-with-label/DisplayTextWithLabel';
 import { CountrySummaryList } from 'components/country-picker/CountryList';
-import Utenlandsopphold from '../../types/domain/Utenlandsopphold';
+import InformasjonOmUtenlandsopphold from '../../types/domain/InformasjonOmUtenlandsopphold';
 import getMessage from 'util/i18n/i18nUtils';
 import { injectIntl, InjectedIntlProps } from 'react-intl';
 
@@ -11,7 +11,7 @@ import '../../styles/engangsstonad.less';
 import SummaryBlock from 'components/summary-block/SummaryBlock';
 
 interface Props {
-    utenlandsopphold: Utenlandsopphold;
+    informasjonOmUtenlandsopphold: InformasjonOmUtenlandsopphold;
     erBarnetFødt?: boolean;
 }
 
@@ -21,9 +21,9 @@ const UtenlandsoppholdOppsummering: React.StatelessComponent<Props & InjectedInt
         fødselINorge,
         iNorgeNeste12Mnd,
         iNorgeSiste12Mnd,
-        tidligerePerioder,
-        senerePerioder
-    } = props.utenlandsopphold;
+        tidligereOpphold,
+        senereOpphold
+    } = props.informasjonOmUtenlandsopphold;
 
     return (
         <SummaryBlock title={getMessage(intl, 'medlemmskap.sectionheading')}>
@@ -37,7 +37,7 @@ const UtenlandsoppholdOppsummering: React.StatelessComponent<Props & InjectedInt
                         <EtikettLiten className="textWithLabel__label">
                             {getMessage(intl, 'oppsummering.text.boddSisteTolv')}
                         </EtikettLiten>
-                        <CountrySummaryList utenlandsoppholdListe={tidligerePerioder} />
+                        <CountrySummaryList utenlandsoppholdListe={tidligereOpphold} />
                     </div>
                 )}
             {iNorgeNeste12Mnd ? (
@@ -50,7 +50,7 @@ const UtenlandsoppholdOppsummering: React.StatelessComponent<Props & InjectedInt
                         <EtikettLiten className="textWithLabel__label">
                             {getMessage(intl, 'medlemmskap.text.oppsummering.neste12mnd')}
                         </EtikettLiten>
-                        <CountrySummaryList utenlandsoppholdListe={senerePerioder} />
+                        <CountrySummaryList utenlandsoppholdListe={senereOpphold} />
                     </div>
                 )}
             {erBarnetFødt === false && fødselINorge !== undefined && (

--- a/src/app/redux/actions/soknad/soknadActionCreators.ts
+++ b/src/app/redux/actions/soknad/soknadActionCreators.ts
@@ -1,5 +1,5 @@
 import { SoknadActionKeys, SoknadActionTypes } from './soknadActionDefinitions';
-import { Periode } from '../../../types/domain/Utenlandsopphold';
+import { Utenlandsopphold } from '../../../types/domain/InformasjonOmUtenlandsopphold';
 
 export function addVedlegg( vedlegg: File[]) {
     return {
@@ -15,14 +15,14 @@ export function deleteVedlegg( vedlegg: File) {
     };
 }
 
-export function addTidligereUtenlandsoppholdPeriode(periode: Periode): SoknadActionTypes {
+export function addTidligereUtenlandsoppholdPeriode(periode: Utenlandsopphold): SoknadActionTypes {
     return {
         type: SoknadActionKeys.ADD_TIDLIGERE_UTENLANDSOPPHOLD_PERIODE,
         periode
     };
 }
 
-export function editTidligereUtenlandsoppholdPeriode(periode: Periode, index: number): SoknadActionTypes {
+export function editTidligereUtenlandsoppholdPeriode(periode: Utenlandsopphold, index: number): SoknadActionTypes {
     return {
         type: SoknadActionKeys.EDIT_TIDLIGERE_UTENLANDSOPPHOLD_PERIODE,
         periode,
@@ -30,21 +30,21 @@ export function editTidligereUtenlandsoppholdPeriode(periode: Periode, index: nu
     };
 }
 
-export function deleteTidligereUtenlandsoppholdPeriode(periode: Periode): SoknadActionTypes {
+export function deleteTidligereUtenlandsoppholdPeriode(periode: Utenlandsopphold): SoknadActionTypes {
     return {
         type: SoknadActionKeys.DELETE_TIDLIGERE_UTENLANDSOPPHOLD_PERIODE,
         periode
     };
 }
 
-export function addSenereUtenlandsoppholdPeriode(periode: Periode): SoknadActionTypes {
+export function addSenereUtenlandsoppholdPeriode(periode: Utenlandsopphold): SoknadActionTypes {
     return {
         type: SoknadActionKeys.ADD_SENERE_UTENLANDSOPPHOLD_PERIODE,
         periode
     };
 }
 
-export function editSenereUtenlandsoppholdPeriode(periode: Periode, index: number): SoknadActionTypes {
+export function editSenereUtenlandsoppholdPeriode(periode: Utenlandsopphold, index: number): SoknadActionTypes {
     return {
         type: SoknadActionKeys.EDIT_SENERE_UTENLANDSOPPHOLD_PERIODE,
         periode,
@@ -52,7 +52,7 @@ export function editSenereUtenlandsoppholdPeriode(periode: Periode, index: numbe
     };
 }
 
-export function deleteSenereUtenlandsoppholdPeriode(periode: Periode): SoknadActionTypes {
+export function deleteSenereUtenlandsoppholdPeriode(periode: Utenlandsopphold): SoknadActionTypes {
     return {
         type: SoknadActionKeys.DELETE_SENERE_UTENLANDSOPPHOLD_PERIODE,
         periode
@@ -78,7 +78,7 @@ export function setFødselsdato(fødselsdato: string): SoknadActionTypes {
         type: SoknadActionKeys.SET_FØDSELSDATO,
         fødselsdato
     };
-} 
+}
 
 export function setTermindato(termindato: string): SoknadActionTypes {
     return {

--- a/src/app/redux/actions/soknad/soknadActionDefinitions.ts
+++ b/src/app/redux/actions/soknad/soknadActionDefinitions.ts
@@ -1,4 +1,4 @@
-import { Periode } from '../../../types/domain/Utenlandsopphold';
+import { Utenlandsopphold } from '../../../types/domain/InformasjonOmUtenlandsopphold';
 
 export enum SoknadActionKeys {
     // RelasjonTilBarn
@@ -73,34 +73,34 @@ interface SetTerminbekreftelseDato {
 // Medlemsskap
 interface AddTidligereUtenlandsoppholdPeriode {
     type: SoknadActionKeys.ADD_TIDLIGERE_UTENLANDSOPPHOLD_PERIODE;
-    periode: Periode;
+    periode: Utenlandsopphold;
 }
 
 interface EditTidligereUtenlandsoppholdPeriode {
     type: SoknadActionKeys.EDIT_TIDLIGERE_UTENLANDSOPPHOLD_PERIODE;
-    periode: Periode;
+    periode: Utenlandsopphold;
     index: number;
 }
 
 interface DeleteTidligereUtenlandsoppholdPeriode {
     type: SoknadActionKeys.DELETE_TIDLIGERE_UTENLANDSOPPHOLD_PERIODE;
-    periode: Periode;
+    periode: Utenlandsopphold;
 }
 
 interface AddSenereUtenlandsoppholdPeriode {
     type: SoknadActionKeys.ADD_SENERE_UTENLANDSOPPHOLD_PERIODE;
-    periode: Periode;
+    periode: Utenlandsopphold;
 }
 
 interface EditSenereUtenlandsoppholdPeriode {
     type: SoknadActionKeys.EDIT_SENERE_UTENLANDSOPPHOLD_PERIODE;
-    periode: Periode;
+    periode: Utenlandsopphold;
     index: number;
 }
 
 interface DeleteSenereUtenlandsoppholdPeriode {
     type: SoknadActionKeys.DELETE_SENERE_UTENLANDSOPPHOLD_PERIODE;
-    periode: Periode;
+    periode: Utenlandsopphold;
 }
 
 interface SetJobbetINorgeSiste12Mnd {

--- a/src/app/redux/reducers/soknadReducer.ts
+++ b/src/app/redux/reducers/soknadReducer.ts
@@ -9,9 +9,9 @@ const getDefaultState = () => {
         barn: {
             fødselsdatoer: []
         },
-        utenlandsopphold: {
-            tidligerePerioder: [],
-            senerePerioder: []
+        informasjonOmUtenlandsopphold: {
+            tidligereOpphold: [],
+            senereOpphold: []
         },
         annenForelder: {}
     };
@@ -19,37 +19,37 @@ const getDefaultState = () => {
 };
 
 const soknadReducer = (state = getDefaultState(), action: SoknadActionTypes | GetAppStateSuccess) => {
-    let { barn, utenlandsopphold } = state;
+    let { barn, informasjonOmUtenlandsopphold } = state;
     switch (action.type) {
         case SoknadActionKeys.ADD_TIDLIGERE_UTENLANDSOPPHOLD_PERIODE:
-            const tidligerePerioder = utenlandsopphold.tidligerePerioder.concat([action.periode]);
-            return { ...state, utenlandsopphold: { ...utenlandsopphold, tidligerePerioder } };
+            const tidligereOpphold = informasjonOmUtenlandsopphold.tidligereOpphold.concat([action.periode]);
+            return { ...state, informasjonOmUtenlandsopphold: { ...informasjonOmUtenlandsopphold, tidligereOpphold } };
         case SoknadActionKeys.EDIT_TIDLIGERE_UTENLANDSOPPHOLD_PERIODE:
-            utenlandsopphold.tidligerePerioder[action.index] = action.periode;
-            return { ...state, utenlandsopphold };
+            informasjonOmUtenlandsopphold.tidligereOpphold[action.index] = action.periode;
+            return { ...state, utenlandsopphold: informasjonOmUtenlandsopphold };
         case SoknadActionKeys.DELETE_TIDLIGERE_UTENLANDSOPPHOLD_PERIODE:
             return {
                 ...state,
-                utenlandsopphold: {
-                    ...utenlandsopphold,
-                    tidligerePerioder: utenlandsopphold.tidligerePerioder.filter((opphold) => {
+                informasjonOmUtenlandsopphold: {
+                    ...informasjonOmUtenlandsopphold,
+                    tidligereOpphold: informasjonOmUtenlandsopphold.tidligereOpphold.filter((opphold) => {
                         return opphold.land !== action.periode.land;
                     })
                 }
             };
 
         case SoknadActionKeys.ADD_SENERE_UTENLANDSOPPHOLD_PERIODE:
-            const senerePerioder = utenlandsopphold.senerePerioder.concat([action.periode]);
-            return { ...state, utenlandsopphold: { ...utenlandsopphold, senerePerioder } };
+            const senereOpphold = informasjonOmUtenlandsopphold.senereOpphold.concat([action.periode]);
+            return { ...state, informasjonOmUtenlandsopphold: { ...informasjonOmUtenlandsopphold, senereOpphold } };
         case SoknadActionKeys.EDIT_SENERE_UTENLANDSOPPHOLD_PERIODE:
-            utenlandsopphold.senerePerioder[action.index] = action.periode;
-            return { ...state, utenlandsopphold };
+            informasjonOmUtenlandsopphold.senereOpphold[action.index] = action.periode;
+            return { ...state, utenlandsopphold: informasjonOmUtenlandsopphold };
         case SoknadActionKeys.DELETE_SENERE_UTENLANDSOPPHOLD_PERIODE:
             return {
                 ...state,
-                utenlandsopphold: {
-                    ...utenlandsopphold,
-                    senerePerioder: utenlandsopphold.senerePerioder.filter((opphold) => {
+                informasjonOmUtenlandsopphold: {
+                    ...informasjonOmUtenlandsopphold,
+                    senereOpphold: informasjonOmUtenlandsopphold.senereOpphold.filter((opphold) => {
                         return opphold.land !== action.periode.land;
                     })
                 }
@@ -57,38 +57,48 @@ const soknadReducer = (state = getDefaultState(), action: SoknadActionTypes | G
 
         case SoknadActionKeys.SET_JOBBET_I_NORGE_SISTE_12_MND:
             const { jobbetINorgeSiste12Mnd } = action;
-            return { ...state, utenlandsopphold: { ...utenlandsopphold, jobbetINorgeSiste12Mnd } };
+            return { ...state, informasjonOmUtenlandsopphold: { ...informasjonOmUtenlandsopphold, jobbetINorgeSiste12Mnd } };
         case SoknadActionKeys.SET_FODSEL_I_NORGE:
             const { fødselINorge } = action;
-            return { ...state, utenlandsopphold: { ...utenlandsopphold, fødselINorge } };
+            return { ...state, informasjonOmUtenlandsopphold: { ...informasjonOmUtenlandsopphold, fødselINorge } };
         case SoknadActionKeys.SET_I_NORGE_SISTE_12_MND:
             const { iNorgeSiste12Mnd } = action;
             return {
-                ...state, utenlandsopphold: {
-                    ...getDefaultState().utenlandsopphold,
+                ...state, informasjonOmUtenlandsopphold: {
+                    ...getDefaultState().informasjonOmUtenlandsopphold,
                     iNorgeSiste12Mnd,
-                    iNorgeNeste12Mnd: state.utenlandsopphold.iNorgeNeste12Mnd,
-                    fødselINorge: state.utenlandsopphold.fødselINorge,
-                    tidligerePerioder: state.utenlandsopphold.tidligerePerioder,
-                    senerePerioder: state.utenlandsopphold.senerePerioder
+                    iNorgeNeste12Mnd: state.informasjonOmUtenlandsopphold.iNorgeNeste12Mnd,
+                    fødselINorge: state.informasjonOmUtenlandsopphold.fødselINorge,
+                    tidligereOpphold: state.informasjonOmUtenlandsopphold.tidligereOpphold,
+                    senereOpphold: state.informasjonOmUtenlandsopphold.senereOpphold
                 }
             };
         case SoknadActionKeys.SET_I_NORGE_NESTE_12_MND:
             const { iNorgeNeste12Mnd } = action;
             return {
                 ...state,
-                utenlandsopphold: {
-                    ...utenlandsopphold,
+                informasjonOmUtenlandsopphold: {
+                    ...informasjonOmUtenlandsopphold,
                     iNorgeNeste12Mnd,
-                    iNorgeSiste12Mnd: state.utenlandsopphold.iNorgeSiste12Mnd,
-                    fødselINorge: state.utenlandsopphold.fødselINorge,
-                    tidligerePerioder: state.utenlandsopphold.tidligerePerioder,
-                    senerePerioder: state.utenlandsopphold.senerePerioder
+                    iNorgeSiste12Mnd: state.informasjonOmUtenlandsopphold.iNorgeSiste12Mnd,
+                    fødselINorge: state.informasjonOmUtenlandsopphold.fødselINorge,
+                    tidligereOpphold: state.informasjonOmUtenlandsopphold.tidligereOpphold,
+                    senereOpphold: state.informasjonOmUtenlandsopphold.senereOpphold
                 }
             };
         case SoknadActionKeys.SET_ER_BARNET_FODT:
             const { erBarnetFødt } = action;
-            return { ...state, barn: { fødselsdatoer: [], erBarnetFødt }, utenlandsopphold: { ...utenlandsopphold, fødselINorge: undefined } };
+            return {
+                ...state,
+                barn: {
+                    fødselsdatoer: [],
+                    erBarnetFødt
+                },
+                informasjonOmUtenlandsopphold: {
+                    ...informasjonOmUtenlandsopphold,
+                    fødselINorge: undefined
+                }
+            };
         case SoknadActionKeys.SET_ANTALL_BARN:
             return { ...state, barn: { ...barn, antallBarn: action.antallBarn } };
         case SoknadActionKeys.SET_FØDSELSDATO:

--- a/src/app/types/domain/EngangsstonadSoknad.ts
+++ b/src/app/types/domain/EngangsstonadSoknad.ts
@@ -1,10 +1,10 @@
-import Utenlandsopphold from './Utenlandsopphold';
+import InformasjonOmUtenlandsopphold from './InformasjonOmUtenlandsopphold';
 import { FodtBarn, UfodtBarn } from './Barn';
 import AnnenForelder from './AnnenForelder';
 
 type EngangsstonadSoknad = {
     type: string;
-    utenlandsopphold: Utenlandsopphold;
+    informasjonOmUtenlandsopphold: InformasjonOmUtenlandsopphold;
     barn: FodtBarn | UfodtBarn;
     annenForelder: AnnenForelder;
 };

--- a/src/app/types/domain/InformasjonOmUtenlandsopphold.ts
+++ b/src/app/types/domain/InformasjonOmUtenlandsopphold.ts
@@ -1,4 +1,4 @@
-export type Periode = {
+export type Utenlandsopphold = {
     land: string;
     varighet: Varighet;
 };
@@ -8,13 +8,13 @@ export type Varighet = {
     fom: string;
 };
 
-type Utenlandsopphold = {
+type InformasjonOmUtenlandsopphold = {
     jobbetINorgeSiste12Mnd?: boolean;
     fødselINorge?: boolean;
     iNorgeSiste12Mnd?: boolean;
     iNorgeNeste12Mnd?: boolean;
-    tidligerePerioder: Periode[];
-    senerePerioder: Periode[];
+    tidligereOpphold: Utenlandsopphold[];
+    senereOpphold: Utenlandsopphold[];
 };
 
-export default Utenlandsopphold;
+export default InformasjonOmUtenlandsopphold;

--- a/src/app/util/apiUtils.ts
+++ b/src/app/util/apiUtils.ts
@@ -2,15 +2,15 @@ import EngangsstonadSoknad from '../types/domain/EngangsstonadSoknad';
 
 export default {
     cleanupSøknad: (søknad: EngangsstonadSoknad) => {
-        const { utenlandsopphold } = søknad;
-        const { iNorgeSiste12Mnd, tidligerePerioder } = utenlandsopphold;
-        const { iNorgeNeste12Mnd, senerePerioder } = utenlandsopphold;
+        const { informasjonOmUtenlandsopphold } = søknad;
+        const { iNorgeSiste12Mnd, tidligereOpphold } = informasjonOmUtenlandsopphold;
+        const { iNorgeNeste12Mnd, senereOpphold } = informasjonOmUtenlandsopphold;
 
-        if (iNorgeSiste12Mnd && tidligerePerioder.length > 0) {
-            søknad.utenlandsopphold.tidligerePerioder = [];
+        if (iNorgeSiste12Mnd && tidligereOpphold.length > 0) {
+            søknad.informasjonOmUtenlandsopphold.tidligereOpphold = [];
         }
-        if (iNorgeNeste12Mnd && senerePerioder.length > 0) {
-            søknad.utenlandsopphold.senerePerioder = [];
+        if (iNorgeNeste12Mnd && senereOpphold.length > 0) {
+            søknad.informasjonOmUtenlandsopphold.senereOpphold = [];
         }
 
         return søknad;

--- a/src/app/util/stepUtil.ts
+++ b/src/app/util/stepUtil.ts
@@ -1,6 +1,6 @@
 import Barn, { UfodtBarn, FodtBarn } from 'app/types/domain/Barn';
 import { dateFormatsAreValid } from 'util/date/dateUtils';
-import Utenlandsopphold from '../types/domain/Utenlandsopphold';
+import InformasjonOmUtenlandsopphold from '../types/domain/InformasjonOmUtenlandsopphold';
 import AnnenForelder from '../types/domain/AnnenForelder';
 import { Attachment } from 'storage/attachment/types/Attachment';
 
@@ -36,17 +36,17 @@ export const shouldDisplayNextButtonOnStep2 = (
     }
 };
 
-export const iNorgeSiste12MndIsValid = (u: Utenlandsopphold) => {
-    return u.iNorgeSiste12Mnd === true || (u.iNorgeSiste12Mnd === false && u.tidligerePerioder.length > 0);
+export const iNorgeSiste12MndIsValid = (u: InformasjonOmUtenlandsopphold) => {
+    return u.iNorgeSiste12Mnd === true || (u.iNorgeSiste12Mnd === false && u.tidligereOpphold.length > 0);
 };
 
-export const iNorgeNeste12MndIsValid = (u: Utenlandsopphold) => {
-    return u.iNorgeNeste12Mnd === true || (u.iNorgeNeste12Mnd === false && u.senerePerioder.length > 0);
+export const iNorgeNeste12MndIsValid = (u: InformasjonOmUtenlandsopphold) => {
+    return u.iNorgeNeste12Mnd === true || (u.iNorgeNeste12Mnd === false && u.senereOpphold.length > 0);
 };
 
 export const shouldDisplayNextButtonOnStep3 = (
     barn: Barn,
-    utenlandsopphold: Utenlandsopphold
+    utenlandsopphold: InformasjonOmUtenlandsopphold
 ) => {
     if (utenlandsopphold.iNorgeNeste12Mnd === false) {
         return ((dateFormatsAreValid((barn as FodtBarn).fødselsdatoer) || utenlandsopphold.fødselINorge !== undefined)) &&


### PR DESCRIPTION
- Renames "utenlandsopphold" to "informasjonOmUtenlandsopphold"
- Renames "tidligerePerioder" to "tidligereOpphold"
- Renames "senerePerioder" to "senereOpphold"

All renamings has been done to ensure consistency between engangsstonad and foreldrepengesoknad.